### PR TITLE
fix volume permissions for debian image

### DIFF
--- a/3/debian-9/Dockerfile
+++ b/3/debian-9/Dockerfile
@@ -30,7 +30,6 @@ ENV ALLOW_ANONYMOUS_LOGIN="no" \
     ZOO_TICK_TIME="2000"
 
 EXPOSE 2181 2888 3888
-RUN mkdir /bitnami/zookeeper
 RUN chown 1001:1001 /bitnami/zookeeper
 USER 1001
 ENTRYPOINT [ "/app-entrypoint.sh" ]

--- a/3/debian-9/Dockerfile
+++ b/3/debian-9/Dockerfile
@@ -30,7 +30,8 @@ ENV ALLOW_ANONYMOUS_LOGIN="no" \
     ZOO_TICK_TIME="2000"
 
 EXPOSE 2181 2888 3888
-
+RUN mkdir /bitnami/zookeeper
+RUN chown 1001:1001 /bitnami/zookeeper
 USER 1001
 ENTRYPOINT [ "/app-entrypoint.sh" ]
 CMD [ "/run.sh" ]


### PR DESCRIPTION
**Description of the change**

Permission for uuid 1001 for volume folder

**Benefits**

If you won't set permission for volume folder docker will create folder on that location with root permissions and zookeeper will fail to use it, container won't start with volume on /bitnami/zookeeper

**Possible drawbacks**

Not sure if this proper way to chown folder as user 1001 doesn't exist before you start a container but at least it works now.

**Applicable issues**

You won't be able to start container without this fix

**Additional information**

Some reference: https://github.com/bitnami/bitnami-docker-kafka/issues/10