### PR TITLE
feat() Added tls for client and quorum communications

### DIFF
--- a/3/debian-10/rootfs/opt/bitnami/scripts/libzookeeper.sh
+++ b/3/debian-10/rootfs/opt/bitnami/scripts/libzookeeper.sh
@@ -63,15 +63,15 @@ export ZOO_PROMETHEUS_METRICS_PORT_NUMBER="${ZOO_PROMETHEUS_METRICS_PORT_NUMBER:
 # Zookeeper TLS Settings
 export ZOO_TLS_CLIENT_ENABLE="${ZOO_TLS_CLIENT_ENABLE:-false}"
 export ZOO_TLS_PORT_NUMBER="${ZOO_TLS_PORT_NUMBER:-3181}"
-export ZOO_TLS_CLIENT_KEYSTORE_PATH="${ZOO_TLS_CLIENT_KEYSTORE_PATH}"
-export ZOO_TLS_CLIENT_KEYSTORE_PASSWORD=$(eval echo $ZOO_TLS_CLIENT_KEYSTORE_PASSWORD)
-export ZOO_TLS_CLIENT_TRUSTSTORE_PATH="${ZOO_TLS_CLIENT_TRUSTSTORE_PATH}"
-export ZOO_TLS_CLIENT_TRUSTSTORE_PASSWORD=$(eval echo $ZOO_TLS_CLIENT_TRUSTSTORE_PASSWORD)
+export ZOO_TLS_CLIENT_KEYSTORE_FILE="${ZOO_TLS_CLIENT_KEYSTORE_FILE:-}"
+export ZOO_TLS_CLIENT_KEYSTORE_PASSWORD="${ZOO_TLS_CLIENT_KEYSTORE_PASSWORD:-}"
+export ZOO_TLS_CLIENT_TRUSTSTORE_FILE="${ZOO_TLS_CLIENT_TRUSTSTORE_FILE:-}"
+export ZOO_TLS_CLIENT_TRUSTSTORE_PASSWORD="${ZOO_TLS_CLIENT_TRUSTSTORE_PASSWORD:-}"
 export ZOO_TLS_QUORUM_ENABLE="${ZOO_TLS_QUORUM_ENABLE:-false}"
-export ZOO_TLS_QUORUM_KEYSTORE_PATH="${ZOO_TLS_QUORUM_KEYSTORE_PATH}"
-export ZOO_TLS_QUORUM_KEYSTORE_PASSWORD=$(eval echo $ZOO_TLS_QUORUM_KEYSTORE_PASSWORD)
-export ZOO_TLS_QUORUM_TRUSTSTORE_PATH="${ZOO_TLS_QUORUM_TRUSTSTORE_PATH}"
-export ZOO_TLS_QUORUM_TRUSTSTORE_PASSWORD=$(eval echo $ZOO_TLS_QUORUM_TRUSTSTORE_PASSWORD)
+export ZOO_TLS_QUORUM_KEYSTORE_FILE="${ZOO_TLS_QUORUM_KEYSTORE_FILE:-}"
+export ZOO_TLS_QUORUM_KEYSTORE_PASSWORD="${ZOO_TLS_QUORUM_KEYSTORE_PASSWORD:-}"
+export ZOO_TLS_QUORUM_TRUSTSTORE_FILE="${ZOO_TLS_QUORUM_TRUSTSTORE_FILE:-}"
+export ZOO_TLS_QUORUM_TRUSTSTORE_PASSWORD="${ZOO_TLS_QUORUM_TRUSTSTORE_PASSWORD:-}"
 
 # Java settings
 export JVMFLAGS="${JVMFLAGS:-}"
@@ -242,23 +242,6 @@ zookeeper_generate_conf() {
     # Set log level
     zookeeper_conf_set "${ZOO_CONF_DIR}/log4j.properties" zookeeper.console.threshold "$ZOO_LOG_LEVEL"
 
-    if [[ $ZOO_TLS_CLIENT_ENABLE = "true" ]]; then
-        zookeeper_conf_set "$ZOO_CONF_FILE" client.secure true
-        zookeeper_conf_set "$ZOO_CONF_FILE" secureClientPort "ZOO_TLS_PORT_NUMBER"
-        zookeeper_conf_set "$ZOO_CONF_FILE" serverCnxnFactory org.apache.zookeeper.server.NettyServerCnxnFactory
-        zookeeper_conf_set "$ZOO_CONF_FILE" ssl.keyStore.location "$ZOO_TLS_CLIENT_KEYSTORE_PATH"
-        zookeeper_conf_set "$ZOO_CONF_FILE" ssl.keyStore.password "$ZOO_TLS_CLIENT_KEYSTORE_PASSWORD"
-        zookeeper_conf_set "$ZOO_CONF_FILE" ssl.trustStore.location "$ZOO_TLS_CLIENT_TRUSTSTORE_PATH"
-        zookeeper_conf_set "$ZOO_CONF_FILE" ssl.trustStore.password "$ZOO_TLS_CLIENT_TRUSTSTORE_PASSWORD"
-    fi
-    if [[ $ZOO_TLS_QUORUM_ENABLE = "true" ]]; then
-        zookeeper_conf_set "$ZOO_CONF_FILE" serverCnxnFactory org.apache.zookeeper.server.NettyServerCnxnFactory
-        zookeeper_conf_set "$ZOO_CONF_FILE" quorum.keyStore.location "$ZOO_TLS_QUORUM_KEYSTORE_PATH"
-        zookeeper_conf_set "$ZOO_CONF_FILE" quorum.keyStore.password "$ZOO_TLS_QUORUM_KEYSTORE_PASSWORD"
-        zookeeper_conf_set "$ZOO_CONF_FILE" quorum.trustStore.location "$ZOO_TLS_QUORUM_TRUSTSTORE_PATH"
-        zookeeper_conf_set "$ZOO_CONF_FILE" quorum.trustStore.password "$ZOO_TLS_QUORUM_TRUSTSTORE_PASSWORD"
-    fi
-
     # Add zookeeper servers to configuration
     read -r -a zookeeper_servers_list <<< "${ZOO_SERVERS//[;, ]/ }"
     if [[ ${#zookeeper_servers_list[@]} -gt 1 ]]; then
@@ -270,6 +253,23 @@ zookeeper_generate_conf() {
         done
     else
         info "No additional servers were specified. ZooKeeper will run in standalone mode..."
+    fi
+
+    # If TLS in enable
+    if [[ "${ZOO_TLS_CLIENT_ENABLE}" = true ]]; then
+        zookeeper_conf_set "$ZOO_CONF_FILE" client.secure true
+        zookeeper_conf_set "$ZOO_CONF_FILE" secureClientPort "$ZOO_TLS_PORT_NUMBER"
+        zookeeper_conf_set "$ZOO_CONF_FILE" serverCnxnFactory org.apache.zookeeper.server.NettyServerCnxnFactory
+        zookeeper_conf_set "$ZOO_CONF_FILE" ssl.keyStore.location "$ZOO_TLS_CLIENT_KEYSTORE_FILE"
+        zookeeper_conf_set "$ZOO_CONF_FILE" ssl.keyStore.password "$ZOO_TLS_CLIENT_KEYSTORE_PASSWORD"
+        zookeeper_conf_set "$ZOO_CONF_FILE" ssl.trustStore.location "$ZOO_TLS_CLIENT_TRUSTSTORE_FILE"
+        zookeeper_conf_set "$ZOO_CONF_FILE" ssl.trustStore.password "$ZOO_TLS_CLIENT_TRUSTSTORE_PASSWORD"
+    fi
+    if [[ "${ZOO_TLS_QUORUM_ENABLE}" = true ]]; then
+        zookeeper_conf_set "$ZOO_CONF_FILE" quorum.keyStore.location "$ZOO_TLS_QUORUM_KEYSTORE_FILE"
+        zookeeper_conf_set "$ZOO_CONF_FILE" quorum.keyStore.password "$ZOO_TLS_QUORUM_KEYSTORE_PASSWORD"
+        zookeeper_conf_set "$ZOO_CONF_FILE" quorum.trustStore.location "$ZOO_TLS_QUORUM_TRUSTSTORE_FILE"
+        zookeeper_conf_set "$ZOO_CONF_FILE" quorum.trustStore.password "$ZOO_TLS_QUORUM_TRUSTSTORE_PASSWORD"
     fi
 }
 

--- a/3/debian-10/rootfs/opt/bitnami/scripts/libzookeeper.sh
+++ b/3/debian-10/rootfs/opt/bitnami/scripts/libzookeeper.sh
@@ -60,6 +60,18 @@ export ZOO_LISTEN_ALLIPS_ENABLED="${ZOO_LISTEN_ALLIPS_ENABLED:-no}"
 export ZOO_ENABLE_PROMETHEUS_METRICS="${ZOO_ENABLE_PROMETHEUS_METRICS:-no}"
 export ZOO_PROMETHEUS_METRICS_PORT_NUMBER="${ZOO_PROMETHEUS_METRICS_PORT_NUMBER:-7000}"
 
+# Zookeeper TLS Settings
+export ZOO_TLS_CLIENT_ENABLE="${ZOO_TLS_CLIENT_ENABLE:-false}"
+export ZOO_TLS_CLIENT_KEYSTORE_PATH="${ZOO_TLS_CLIENT_KEYSTORE_PATH}"
+export ZOO_TLS_CLIENT_KEYSTORE_PASSWORD=$(eval echo $ZOO_TLS_CLIENT_KEYSTORE_PASSWORD)
+export ZOO_TLS_CLIENT_TRUSTSTORE_PATH="${ZOO_TLS_CLIENT_TRUSTSTORE_PATH}"
+export ZOO_TLS_CLIENT_TRUSTSTORE_PASSWORD=$(eval echo $ZOO_TLS_CLIENT_TRUSTSTORE_PASSWORD)
+export ZOO_TLS_QUORUM_ENABLE="${ZOO_TLS_QUORUM_ENABLE:-false}"
+export ZOO_TLS_QUORUM_KEYSTORE_PATH="${ZOO_TLS_QUORUM_KEYSTORE_PATH}"
+export ZOO_TLS_QUORUM_KEYSTORE_PASSWORD=$(eval echo $ZOO_TLS_QUORUM_KEYSTORE_PASSWORD)
+export ZOO_TLS_QUORUM_TRUSTSTORE_PATH="${ZOO_TLS_QUORUM_TRUSTSTORE_PATH}"
+export ZOO_TLS_QUORUM_TRUSTSTORE_PASSWORD=$(eval echo $ZOO_TLS_QUORUM_TRUSTSTORE_PASSWORD)
+
 # Java settings
 export JVMFLAGS="${JVMFLAGS:-}"
 export ZOO_HEAP_SIZE="${ZOO_HEAP_SIZE:-1024}"
@@ -228,6 +240,22 @@ zookeeper_generate_conf() {
     zookeeper_conf_set "$ZOO_CONF_FILE" 4lw.commands.whitelist "$ZOO_4LW_COMMANDS_WHITELIST"
     # Set log level
     zookeeper_conf_set "${ZOO_CONF_DIR}/log4j.properties" zookeeper.console.threshold "$ZOO_LOG_LEVEL"
+
+    if [[ $ZOO_TLS_CLIENT_ENABLE = "true" ]]; then
+        zookeeper_conf_set "$ZOO_CONF_FILE" client.secure true
+        zookeeper_conf_set "$ZOO_CONF_FILE" secureClientPort 3181
+        zookeeper_conf_set "$ZOO_CONF_FILE" serverCnxnFactory org.apache.zookeeper.server.NettyServerCnxnFactory
+        zookeeper_conf_set "$ZOO_CONF_FILE" ssl.keyStore.location "$ZOO_TLS_CLIENT_KEYSTORE_PATH"
+        zookeeper_conf_set "$ZOO_CONF_FILE" ssl.keyStore.password "$ZOO_TLS_CLIENT_KEYSTORE_PASSWORD"
+        zookeeper_conf_set "$ZOO_CONF_FILE" ssl.trustStore.location "$ZOO_TLS_CLIENT_TRUSTSTORE_PATH"
+        zookeeper_conf_set "$ZOO_CONF_FILE" ssl.trustStore.password "$ZOO_TLS_CLIENT_TRUSTSTORE_PASSWORD"
+    fi
+    if [[ $ZOO_TLS_QUORUM_ENABLE = "true" ]]; then
+        zookeeper_conf_set "$ZOO_CONF_FILE" quorum.keyStore.location "$ZOO_TLS_QUORUM_KEYSTORE_PATH"
+        zookeeper_conf_set "$ZOO_CONF_FILE" quorum.keyStore.password "$ZOO_TLS_QUORUM_KEYSTORE_PASSWORD"
+        zookeeper_conf_set "$ZOO_CONF_FILE" quorum.trustStore.location "$ZOO_TLS_QUORUM_TRUSTSTORE_PATH"
+        zookeeper_conf_set "$ZOO_CONF_FILE" quorum.trustStore.password "$ZOO_TLS_QUORUM_TRUSTSTORE_PASSWORD"
+    fi
 
     # Add zookeeper servers to configuration
     read -r -a zookeeper_servers_list <<< "${ZOO_SERVERS//[;, ]/ }"

--- a/3/debian-10/rootfs/opt/bitnami/scripts/libzookeeper.sh
+++ b/3/debian-10/rootfs/opt/bitnami/scripts/libzookeeper.sh
@@ -62,6 +62,7 @@ export ZOO_PROMETHEUS_METRICS_PORT_NUMBER="${ZOO_PROMETHEUS_METRICS_PORT_NUMBER:
 
 # Zookeeper TLS Settings
 export ZOO_TLS_CLIENT_ENABLE="${ZOO_TLS_CLIENT_ENABLE:-false}"
+export ZOO_TLS_PORT_NUMBER="${ZOO_TLS_PORT_NUMBER:-3181}"
 export ZOO_TLS_CLIENT_KEYSTORE_PATH="${ZOO_TLS_CLIENT_KEYSTORE_PATH}"
 export ZOO_TLS_CLIENT_KEYSTORE_PASSWORD=$(eval echo $ZOO_TLS_CLIENT_KEYSTORE_PASSWORD)
 export ZOO_TLS_CLIENT_TRUSTSTORE_PATH="${ZOO_TLS_CLIENT_TRUSTSTORE_PATH}"
@@ -243,7 +244,7 @@ zookeeper_generate_conf() {
 
     if [[ $ZOO_TLS_CLIENT_ENABLE = "true" ]]; then
         zookeeper_conf_set "$ZOO_CONF_FILE" client.secure true
-        zookeeper_conf_set "$ZOO_CONF_FILE" secureClientPort 3181
+        zookeeper_conf_set "$ZOO_CONF_FILE" secureClientPort "ZOO_TLS_PORT_NUMBER"
         zookeeper_conf_set "$ZOO_CONF_FILE" serverCnxnFactory org.apache.zookeeper.server.NettyServerCnxnFactory
         zookeeper_conf_set "$ZOO_CONF_FILE" ssl.keyStore.location "$ZOO_TLS_CLIENT_KEYSTORE_PATH"
         zookeeper_conf_set "$ZOO_CONF_FILE" ssl.keyStore.password "$ZOO_TLS_CLIENT_KEYSTORE_PASSWORD"
@@ -251,6 +252,7 @@ zookeeper_generate_conf() {
         zookeeper_conf_set "$ZOO_CONF_FILE" ssl.trustStore.password "$ZOO_TLS_CLIENT_TRUSTSTORE_PASSWORD"
     fi
     if [[ $ZOO_TLS_QUORUM_ENABLE = "true" ]]; then
+        zookeeper_conf_set "$ZOO_CONF_FILE" serverCnxnFactory org.apache.zookeeper.server.NettyServerCnxnFactory
         zookeeper_conf_set "$ZOO_CONF_FILE" quorum.keyStore.location "$ZOO_TLS_QUORUM_KEYSTORE_PATH"
         zookeeper_conf_set "$ZOO_CONF_FILE" quorum.keyStore.password "$ZOO_TLS_QUORUM_KEYSTORE_PASSWORD"
         zookeeper_conf_set "$ZOO_CONF_FILE" quorum.trustStore.location "$ZOO_TLS_QUORUM_TRUSTSTORE_PATH"

--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ The configuration can easily be setup with the Bitnami ZooKeeper Docker image us
  - `ZOO_ENABLE_PROMETHEUS_METRICS`: Expose Prometheus metrics. Default: **no**
  - `ZOO_PROMETHEUS_METRICS_PORT_NUMBER`: Port where a Jetty server will expose Prometheus metrics. Default: **7000**
  - `ZOO_TLS_CLIENT_ENABLE`: Enable tls for client communication. Default: **false**
+ - `ZOO_TLS_PORT_NUMBER`: ZooKeeper client port if using TLS_CLIENT. Default: **3181**
  - `ZOO_TLS_CLIENT_KEYSTORE_PATH`: KeyStore file path: Default: No Defaults
  - `ZOO_TLS_CLIENT_KEYSTORE_PASSWORD`: KeyStore file password. This can be an evironment variable. It will be evaled by bash. No Defaults
  - `ZOO_TLS_CLIENT_TRUSTSTORE_PATH`: TrustStore file path: Default: No Defaults

--- a/README.md
+++ b/README.md
@@ -200,6 +200,16 @@ The configuration can easily be setup with the Bitnami ZooKeeper Docker image us
  - `ZOO_HEAP_SIZE`: Size in MB for the Java Heap options (Xmx and XMs). This env var is ignored if Xmx an Xms are configured via `JVMFLAGS`. Default: **1024**
  - `ZOO_ENABLE_PROMETHEUS_METRICS`: Expose Prometheus metrics. Default: **no**
  - `ZOO_PROMETHEUS_METRICS_PORT_NUMBER`: Port where a Jetty server will expose Prometheus metrics. Default: **7000**
+ - `ZOO_TLS_CLIENT_ENABLE`: Enable tls for client communication. Default: **false**
+ - `ZOO_TLS_CLIENT_KEYSTORE_PATH`: KeyStore file path: Default: No Defaults
+ - `ZOO_TLS_CLIENT_KEYSTORE_PASSWORD`: KeyStore file password. This can be an evironment variable. It will be evaled by bash. No Defaults
+ - `ZOO_TLS_CLIENT_TRUSTSTORE_PATH`: TrustStore file path: Default: No Defaults
+ - `ZOO_TLS_CLIENT_TRUSTSTORE_PASSWORD`: TrustStore file password. This can be an evironment variable. It will be evaled by bash. No Defaults
+ - `ZOO_TLS_QUORUM_ENABLE`: Enable tls for quorum communication. Default: **false**
+ - `ZOO_TLS_QUORUM_KEYSTORE_PATH`: KeyStore file path: Default: No Defaults
+ - `ZOO_TLS_QUORUM_KEYSTORE_PASSWORD`: KeyStore file password. This can be an evironment variable. It will be evaled by bash. No Defaults
+ - `ZOO_TLS_QUORUM_KEYSTORE_PATH`: TrustStore file path: Default: No Defaults
+ - `ZOO_TLS_QUORUM_KEYSTORE_PASSWORD`: TrustStore file password. This can be an evironment variable. It will be evaled by bash. No Defaults
  - `ALLOW_ANONYMOUS_LOGIN`: If set to true, Allow to accept connections from unauthenticated users. Default: **no**
  - `ZOO_LOG_LEVEL`: ZooKeeper log level. Available levels are: `ALL`, `DEBUG`, `INFO`, `WARN`, `ERROR`, `FATAL`, `OFF`, `TRACE`. Default: **INFO**
  - `JVMFLAGS`: Default JVMFLAGS for the ZooKeeper process. No defaults

--- a/README.md
+++ b/README.md
@@ -198,20 +198,20 @@ The configuration can easily be setup with the Bitnami ZooKeeper Docker image us
  - `ZOO_HEAP_SIZE`: Size in MB for the Java Heap options (Xmx and XMs). This env var is ignored if Xmx an Xms are configured via `JVMFLAGS`. Default: **1024**
  - `ZOO_ENABLE_PROMETHEUS_METRICS`: Expose Prometheus metrics. Default: **no**
  - `ZOO_PROMETHEUS_METRICS_PORT_NUMBER`: Port where a Jetty server will expose Prometheus metrics. Default: **7000**
- - `ZOO_TLS_CLIENT_ENABLE`: Enable tls for client communication. Default: **false**
- - `ZOO_TLS_PORT_NUMBER`: ZooKeeper client port if using TLS_CLIENT. Default: **3181**
- - `ZOO_TLS_CLIENT_KEYSTORE_PATH`: KeyStore file path: Default: No Defaults
- - `ZOO_TLS_CLIENT_KEYSTORE_PASSWORD`: KeyStore file password. This can be an evironment variable. It will be evaled by bash. No Defaults
- - `ZOO_TLS_CLIENT_TRUSTSTORE_PATH`: TrustStore file path: Default: No Defaults
- - `ZOO_TLS_CLIENT_TRUSTSTORE_PASSWORD`: TrustStore file password. This can be an evironment variable. It will be evaled by bash. No Defaults
- - `ZOO_TLS_QUORUM_ENABLE`: Enable tls for quorum communication. Default: **false**
- - `ZOO_TLS_QUORUM_KEYSTORE_PATH`: KeyStore file path: Default: No Defaults
- - `ZOO_TLS_QUORUM_KEYSTORE_PASSWORD`: KeyStore file password. This can be an evironment variable. It will be evaled by bash. No Defaults
- - `ZOO_TLS_QUORUM_KEYSTORE_PATH`: TrustStore file path: Default: No Defaults
- - `ZOO_TLS_QUORUM_KEYSTORE_PASSWORD`: TrustStore file password. This can be an evironment variable. It will be evaled by bash. No Defaults
  - `ALLOW_ANONYMOUS_LOGIN`: If set to true, Allow to accept connections from unauthenticated users. Default: **no**
  - `ZOO_LOG_LEVEL`: ZooKeeper log level. Available levels are: `ALL`, `DEBUG`, `INFO`, `WARN`, `ERROR`, `FATAL`, `OFF`, `TRACE`. Default: **INFO**
  - `JVMFLAGS`: Default JVMFLAGS for the ZooKeeper process. No defaults
+ - `ZOO_TLS_CLIENT_ENABLE`: Enable tls for client communication. Default: **false**
+ - `ZOO_TLS_PORT_NUMBER`: Zookeeper TLS port. Default: 3181
+ - `ZOO_TLS_CLIENT_KEYSTORE_FILE`: KeyStore file file: Default: No Defaults
+ - `ZOO_TLS_CLIENT_KEYSTORE_PASSWORD`: KeyStore file password. This can be an evironment variable. It will be evaled by bash. No Defaults
+ - `ZOO_TLS_CLIENT_TRUSTSTORE_FILE`: TrustStore file file: Default: No Defaults
+ - `ZOO_TLS_CLIENT_TRUSTSTORE_PASSWORD`: TrustStore file password. This can be an evironment variable. It will be evaled by bash. No Defaults
+ - `ZOO_TLS_QUORUM_ENABLE`: Enable tls for quorum communication. Default: **false**
+ - `ZOO_TLS_QUORUM_KEYSTORE_FILE`: KeyStore file file: Default: No Defaults
+ - `ZOO_TLS_QUORUM_KEYSTORE_PASSWORD`: KeyStore file password. This can be an evironment variable. It will be evaled by bash. No Defaults
+ - `ZOO_TLS_QUORUM_KEYSTORE_FILE`: TrustStore file file: Default: No Defaults
+ - `ZOO_TLS_QUORUM_KEYSTORE_PASSWORD`: TrustStore file password. This can be an evironment variable. It will be evaled by bash. No Defaults
 
 ```console
 $ docker run --name zookeeper -e ZOO_SERVER_ID=1 bitnami/zookeeper:latest


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

This change adds tls support for client and quorum communication

**Benefits**

Production clusters can benefit from secure communication

**Possible drawbacks**

You need to prepare keyStore and trustStore files manually and introduce into the running container.

**Applicable issues**


**Additional information**

