### PR TITLE
Quorum ssl parameter missing from tls changes

### DIFF
--- a/3/debian-10/rootfs/opt/bitnami/scripts/libzookeeper.sh
+++ b/3/debian-10/rootfs/opt/bitnami/scripts/libzookeeper.sh
@@ -268,10 +268,10 @@ zookeeper_generate_conf() {
     if [[ "${ZOO_TLS_QUORUM_ENABLE}" = true ]]; then
         zookeeper_conf_set "$ZOO_CONF_FILE" sslQuorum true
         zookeeper_conf_set "$ZOO_CONF_FILE" serverCnxnFactory org.apache.zookeeper.server.NettyServerCnxnFactory
-        zookeeper_conf_set "$ZOO_CONF_FILE" quorum.keyStore.location "$ZOO_TLS_QUORUM_KEYSTORE_FILE"
-        zookeeper_conf_set "$ZOO_CONF_FILE" quorum.keyStore.password "$ZOO_TLS_QUORUM_KEYSTORE_PASSWORD"
-        zookeeper_conf_set "$ZOO_CONF_FILE" quorum.trustStore.location "$ZOO_TLS_QUORUM_TRUSTSTORE_FILE"
-        zookeeper_conf_set "$ZOO_CONF_FILE" quorum.trustStore.password "$ZOO_TLS_QUORUM_TRUSTSTORE_PASSWORD"
+        zookeeper_conf_set "$ZOO_CONF_FILE" ssl.quorum.keyStore.location "$ZOO_TLS_QUORUM_KEYSTORE_FILE"
+        zookeeper_conf_set "$ZOO_CONF_FILE" ssl.quorum.keyStore.password "$ZOO_TLS_QUORUM_KEYSTORE_PASSWORD"
+        zookeeper_conf_set "$ZOO_CONF_FILE" ssl.quorum.trustStore.location "$ZOO_TLS_QUORUM_TRUSTSTORE_FILE"
+        zookeeper_conf_set "$ZOO_CONF_FILE" ssl.quorum.trustStore.password "$ZOO_TLS_QUORUM_TRUSTSTORE_PASSWORD"
     fi
 }
 

--- a/3/debian-10/rootfs/opt/bitnami/scripts/libzookeeper.sh
+++ b/3/debian-10/rootfs/opt/bitnami/scripts/libzookeeper.sh
@@ -266,6 +266,8 @@ zookeeper_generate_conf() {
         zookeeper_conf_set "$ZOO_CONF_FILE" ssl.trustStore.password "$ZOO_TLS_CLIENT_TRUSTSTORE_PASSWORD"
     fi
     if [[ "${ZOO_TLS_QUORUM_ENABLE}" = true ]]; then
+        zookeeper_conf_set "$ZOO_CONF_FILE" sslQuorum true
+        zookeeper_conf_set "$ZOO_CONF_FILE" serverCnxnFactory org.apache.zookeeper.server.NettyServerCnxnFactory
         zookeeper_conf_set "$ZOO_CONF_FILE" quorum.keyStore.location "$ZOO_TLS_QUORUM_KEYSTORE_FILE"
         zookeeper_conf_set "$ZOO_CONF_FILE" quorum.keyStore.password "$ZOO_TLS_QUORUM_KEYSTORE_PASSWORD"
         zookeeper_conf_set "$ZOO_CONF_FILE" quorum.trustStore.location "$ZOO_TLS_QUORUM_TRUSTSTORE_FILE"


### PR DESCRIPTION
Description of the change

- This change adds sslQuorum=true in case quorum ssl is enabled.
- Also, If $ZOO_TLS_CLIENT_ENABLE = "false" but $ZOO_TLS_QUORUM_ENABLE = "true", zookeeper_conf_set "$ZOO_CONF_FILE" serverCnxnFactory org.apache.zookeeper.server.NettyServerCnxnFactory should be added.
- Quorum parameters need to be appended with "ssl" e.g. "ssl.quorum.keyStore" instead of "quorum.keyStore"

Benefits

Possible drawbacks

Applicable issues

Additional information
