### PR TITLE
Configurable dataLogDir.

### DIFF
--- a/3/debian-10/Dockerfile
+++ b/3/debian-10/Dockerfile
@@ -22,7 +22,7 @@ RUN ln -s /opt/bitnami/scripts/zookeeper/run.sh /run.sh
 COPY rootfs /
 RUN /opt/bitnami/scripts/zookeeper/postunpack.sh
 ENV BITNAMI_APP_NAME="zookeeper" \
-    BITNAMI_IMAGE_VERSION="3.6.1-debian-10-r63"
+    BITNAMI_IMAGE_VERSION="3.6.1-debian-10-r64"
 
 EXPOSE 2181 2888 3888 8080
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Non-root container images add an extra layer of security and are generally recom
 Learn more about the Bitnami tagging policy and the difference between rolling tags and immutable tags [in our documentation page](https://docs.bitnami.com/tutorials/understand-rolling-tags-containers/).
 
 
-* [`3-debian-10`, `3.6.1-debian-10-r63`, `3`, `3.6.1`, `latest` (3/debian-10/Dockerfile)](https://github.com/bitnami/bitnami-docker-zookeeper/blob/3.6.1-debian-10-r63/3/debian-10/Dockerfile)
+* [`3-debian-10`, `3.6.1-debian-10-r64`, `3`, `3.6.1`, `latest` (3/debian-10/Dockerfile)](https://github.com/bitnami/bitnami-docker-zookeeper/blob/3.6.1-debian-10-r64/3/debian-10/Dockerfile)
 
 Subscribe to project updates by watching the [bitnami/zookeeper GitHub repo](https://github.com/bitnami/bitnami-docker-zookeeper).
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Updated libzookeeper.sh to handle an optional ZOO_DATA_LOG_DIR env and update the dataLogDir property in zoo.conf appropriately.

**Benefits**

From:
https://zookeeper.apache.org/doc/r3.6.1/zookeeperAdmin.html#sc_advancedConfiguration

> dataLogDir : (No Java system property) This option will direct the machine to write the transaction log to the dataLogDir rather than the dataDir. This allows a dedicated log device to be used, and helps avoid competition between logging and snapshots.
Note
Having a dedicated log device has a large impact on throughput and stable latencies. It is highly recommended to dedicate a log device and set dataLogDir to point to a directory on that device, and then make sure to point dataDir to a directory not residing on that device.

**Possible drawbacks**

I can't think of any.

**Applicable issues**

This PR addresses the zookeeper image change needed to implement the feature request on the bitnami/zookeeper helm chart:
https://github.com/bitnami/charts/issues/2902

A subsequent PR will be made to the chart repository will be made to take advantage of this change.

**Additional information**

N/A
