### PR TITLE
automatically set -x when BITNAMI_DEBUG is set

### DIFF
--- a/3/debian-10/rootfs/opt/bitnami/scripts/libzookeeper.sh
+++ b/3/debian-10/rootfs/opt/bitnami/scripts/libzookeeper.sh
@@ -27,6 +27,7 @@ zookeeper_env() {
 # Format log messages
 export MODULE=zookeeper
 export BITNAMI_DEBUG=${BITNAMI_DEBUG:-false}
+export BITNAMI_TRACE=${BITNAMI_TRACE:-false}
 
 # Paths
 export ZOO_BASE_DIR="/opt/bitnami/zookeeper"

--- a/3/debian-10/rootfs/opt/bitnami/scripts/zookeeper/entrypoint.sh
+++ b/3/debian-10/rootfs/opt/bitnami/scripts/zookeeper/entrypoint.sh
@@ -5,7 +5,9 @@
 set -o errexit
 set -o nounset
 set -o pipefail
-# set -o xtrace # Uncomment this line for debugging purposes
+if [[ "${BITNAMI_TRACE:-false}" != "false" ]]; then
+    set -o xtrace
+fi
 
 # Load libraries
 . /opt/bitnami/scripts/liblog.sh

--- a/3/debian-10/rootfs/opt/bitnami/scripts/zookeeper/run.sh
+++ b/3/debian-10/rootfs/opt/bitnami/scripts/zookeeper/run.sh
@@ -5,7 +5,9 @@
 set -o errexit
 set -o nounset
 set -o pipefail
-# set -o xtrace # Uncomment this line for debugging purposes
+if [[ "${BITNAMI_TRACE:-false}" != "false" ]]; then
+    set -o xtrace
+fi
 
 # Load libraries
 . /opt/bitnami/scripts/libzookeeper.sh

--- a/3/debian-10/rootfs/opt/bitnami/scripts/zookeeper/setup.sh
+++ b/3/debian-10/rootfs/opt/bitnami/scripts/zookeeper/setup.sh
@@ -5,7 +5,9 @@
 set -o errexit
 set -o nounset
 set -o pipefail
-# set -o xtrace # Uncomment this line for debugging purposes
+if [[ "${BITNAMI_DEBUG:-false}" != "false" ]]; then
+    set -o xtrace
+fi
 
 # Load libraries
 . /opt/bitnami/scripts/libfs.sh


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

automatically set -o xtrace when BITNAMI_DEBUG is "true".

**Benefits**

enable user to enable `-x` by simply setting a environment variable, instead of manually installing a text editor and then edit the shell scripts inside container.

**Possible drawbacks**

None

**Applicable issues**

* inconvenience when debugging startup problems inside kubernetes cluster

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->