### PR TITLE
Make TLS client authentication configurable through env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,11 +208,13 @@ The configuration can easily be setup with the Bitnami ZooKeeper Docker image us
  - `ZOO_TLS_CLIENT_KEYSTORE_PASSWORD`: KeyStore file password. This can be an environment variable. It will be evaluated by bash. No Defaults
  - `ZOO_TLS_CLIENT_TRUSTSTORE_FILE`: TrustStore file: Default: No Defaults
  - `ZOO_TLS_CLIENT_TRUSTSTORE_PASSWORD`: TrustStore file password. This can be an environment variable. It will be evaluated by bash. No Defaults
+ - `ZOO_TLS_CLIENT_AUTH`: Specifies options to authenticate TLS connections from clients. Available values are: `none`, `want`, `need`. Default: **need**
  - `ZOO_TLS_QUORUM_ENABLE`: Enable tls for quorum communication. Default: **false**
  - `ZOO_TLS_QUORUM_KEYSTORE_FILE`: KeyStore file: Default: No Defaults
  - `ZOO_TLS_QUORUM_KEYSTORE_PASSWORD`: KeyStore file password. This can be an environment variable. It will be evaluated by bash. No Defaults
  - `ZOO_TLS_QUORUM_TRUSTSTORE_FILE`: TrustStore file: Default: No Defaults
  - `ZOO_TLS_QUORUM_TRUSTSTORE_PASSWORD`: TrustStore file password. This can be an environment variable. It will be evaluated by bash. No Defaults
+ - `ZOO_TLS_QUORUM_CLIENT_AUTH`: Specifies options to authenticate TLS connections from clients. Available values are: `none`, `want`, `need`. Default: **need**
 
 ```console
 $ docker run --name zookeeper -e ZOO_SERVER_ID=1 bitnami/zookeeper:latest


### PR DESCRIPTION
**Description of the change**

Adds `ZOO_TLS_CLIENT_AUTH` and `ZOO_TLS_QUORUM_CLIENT_AUTH` environment variables to configure zookeeper's ssl.clientAuth and ssl.quorum.clientAuth options.

Valid values are:
- `none`: server will not request client authentication
- `want`: server will "request" client authentication
- `need`: server will "require" client authentication

The default value is `need`, making it backwards compatible.

**Benefits**

While mTLS offers client authentication and encryption, in some scenarios, provisioning client certificates can become a burden. If client authentication can be disabled encryption can still be maintained while simplifying provisiong/deployment.

**Possible drawbacks**

These options only have effect from Zookeeper version 3.5.7 onwards (even though the options were added in version 3.5.5)

**Applicable issues**

[An analogous PR was made in the bitnami-kafka-repo](https://github.com/bitnami/bitnami-docker-kafka/pull/142)

**Additional information**

More info on ssl.clientAuth: https://zookeeper.apache.org/doc/r3.6.2/zookeeperAdmin.html
