### PR TITLE
ZOO_ENABLE_ADMIN_SERVER, ZOO_ADMIN_SERVER_PORT_NUMBER added for Zookeeper admin server, version 3.7

### DIFF
--- a/3.7/debian-10/rootfs/opt/bitnami/scripts/libzookeeper.sh
+++ b/3.7/debian-10/rootfs/opt/bitnami/scripts/libzookeeper.sh
@@ -73,7 +73,7 @@ zookeeper_validate() {
     check_conflicting_ports ZOO_PORT_NUMBER ZOO_PROMETHEUS_METRICS_PORT_NUMBER
 
     is_boolean_yes "$ZOO_ENABLE_ADMIN_SERVER" && check_allowed_port ZOO_ADMIN_SERVER_PORT_NUMBER
-    is_boolean_yes "$ZOO_ENABLE_ADMIN_SERVER" && check_allowed_port ZOO_PORT_NUMBER ZOO_PROMETHEUS_METRICS_PORT_NUMBER ZOO_ADMIN_SERVER_PORT_NUMBER
+    is_boolean_yes "$ZOO_ENABLE_ADMIN_SERVER" && check_conflicting_ports ZOO_PORT_NUMBER ZOO_PROMETHEUS_METRICS_PORT_NUMBER ZOO_ADMIN_SERVER_PORT_NUMBER
 
     # ZooKeeper server users validations
     read -r -a server_users_list <<< "${ZOO_SERVER_USERS//[;, ]/ }"

--- a/3.7/debian-10/rootfs/opt/bitnami/scripts/libzookeeper.sh
+++ b/3.7/debian-10/rootfs/opt/bitnami/scripts/libzookeeper.sh
@@ -70,7 +70,18 @@ zookeeper_validate() {
     check_allowed_port ZOO_PORT_NUMBER
     check_allowed_port ZOO_PROMETHEUS_METRICS_PORT_NUMBER
 
+    if is_boolean_yes "$ZOO_ADMIN_SERVER_ENABLE"; then
+      echo "Admin web server is enabled on port ${ZOO_ADMIN_SERVER_PORT_NUMBER}."
+      check_allowed_port ZOO_ADMIN_SERVER_PORT_NUMBER
+    else
+      echo "Admin web server is disabled."
+    fi
+
     check_conflicting_ports ZOO_PORT_NUMBER ZOO_PROMETHEUS_METRICS_PORT_NUMBER
+
+    if is_boolean_yes "$ZOO_ADMIN_SERVER_ENABLE"; then
+      check_conflicting_ports ZOO_PORT_NUMBER ZOO_PROMETHEUS_METRICS_PORT_NUMBER ZOO_ADMIN_SERVER_PORT_NUMBER
+    fi
 
     # ZooKeeper server users validations
     read -r -a server_users_list <<< "${ZOO_SERVER_USERS//[;, ]/ }"
@@ -173,6 +184,10 @@ zookeeper_generate_conf() {
     zookeeper_conf_set "$ZOO_CONF_FILE" maxSessionTimeout "$ZOO_MAX_SESSION_TIMEOUT"
     # Set log level
     zookeeper_conf_set "${ZOO_CONF_DIR}/log4j.properties" zookeeper.console.threshold "$ZOO_LOG_LEVEL"
+
+    # Admin web server https://zookeeper.apache.org/doc/r3.5.7/zookeeperAdmin.html#sc_adminserver
+    zookeeper_conf_set "$ZOO_CONF_FILE" admin.serverPort "$ZOO_ADMIN_SERVER_PORT_NUMBER"
+    zookeeper_conf_set "$ZOO_CONF_FILE" admin.enableServer "$ZOO_ADMIN_SERVER_ENABLE"
 
     # Add zookeeper servers to configuration
     server_id_with_jumps="no"

--- a/3.7/debian-10/rootfs/opt/bitnami/scripts/libzookeeper.sh
+++ b/3.7/debian-10/rootfs/opt/bitnami/scripts/libzookeeper.sh
@@ -70,18 +70,10 @@ zookeeper_validate() {
     check_allowed_port ZOO_PORT_NUMBER
     check_allowed_port ZOO_PROMETHEUS_METRICS_PORT_NUMBER
 
-    if is_boolean_yes "$ZOO_ADMIN_SERVER_ENABLE"; then
-      echo "Admin web server is enabled on port ${ZOO_ADMIN_SERVER_PORT_NUMBER}."
-      check_allowed_port ZOO_ADMIN_SERVER_PORT_NUMBER
-    else
-      echo "Admin web server is disabled."
-    fi
-
     check_conflicting_ports ZOO_PORT_NUMBER ZOO_PROMETHEUS_METRICS_PORT_NUMBER
 
-    if is_boolean_yes "$ZOO_ADMIN_SERVER_ENABLE"; then
-      check_conflicting_ports ZOO_PORT_NUMBER ZOO_PROMETHEUS_METRICS_PORT_NUMBER ZOO_ADMIN_SERVER_PORT_NUMBER
-    fi
+    is_boolean_yes "$ZOO_ENABLE_ADMIN_SERVER" && check_allowed_port ZOO_ADMIN_SERVER_PORT_NUMBER
+    is_boolean_yes "$ZOO_ENABLE_ADMIN_SERVER" && check_allowed_port ZOO_PORT_NUMBER ZOO_PROMETHEUS_METRICS_PORT_NUMBER ZOO_ADMIN_SERVER_PORT_NUMBER
 
     # ZooKeeper server users validations
     read -r -a server_users_list <<< "${ZOO_SERVER_USERS//[;, ]/ }"
@@ -187,7 +179,7 @@ zookeeper_generate_conf() {
 
     # Admin web server https://zookeeper.apache.org/doc/r3.5.7/zookeeperAdmin.html#sc_adminserver
     zookeeper_conf_set "$ZOO_CONF_FILE" admin.serverPort "$ZOO_ADMIN_SERVER_PORT_NUMBER"
-    zookeeper_conf_set "$ZOO_CONF_FILE" admin.enableServer "$ZOO_ADMIN_SERVER_ENABLE"
+    zookeeper_conf_set "$ZOO_CONF_FILE" admin.enableServer "$ZOO_ENABLE_ADMIN_SERVER"
 
     # Add zookeeper servers to configuration
     server_id_with_jumps="no"

--- a/3.7/debian-10/rootfs/opt/bitnami/scripts/libzookeeper.sh
+++ b/3.7/debian-10/rootfs/opt/bitnami/scripts/libzookeeper.sh
@@ -179,7 +179,7 @@ zookeeper_generate_conf() {
 
     # Admin web server https://zookeeper.apache.org/doc/r3.5.7/zookeeperAdmin.html#sc_adminserver
     zookeeper_conf_set "$ZOO_CONF_FILE" admin.serverPort "$ZOO_ADMIN_SERVER_PORT_NUMBER"
-    zookeeper_conf_set "$ZOO_CONF_FILE" admin.enableServer "$ZOO_ENABLE_ADMIN_SERVER"
+    zookeeper_conf_set "$ZOO_CONF_FILE" admin.enableServer "$(is_boolean_yes "$ZOO_ENABLE_ADMIN_SERVER" && echo "true" || echo "false")"
 
     # Add zookeeper servers to configuration
     server_id_with_jumps="no"

--- a/3.7/debian-10/rootfs/opt/bitnami/scripts/zookeeper-env.sh
+++ b/3.7/debian-10/rootfs/opt/bitnami/scripts/zookeeper-env.sh
@@ -63,7 +63,7 @@ zookeeper_env_vars=(
     ZOO_CLIENT_PASSWORD
     ZOO_SERVER_PASSWORDS
     ZOO_ADMIN_SERVER_PORT_NUMBER
-    ZOO_ADMIN_SERVER_ENABLE
+    ZOO_ENABLE_ADMIN_SERVER
 )
 for env_var in "${zookeeper_env_vars[@]}"; do
     file_env_var="${env_var}_FILE"
@@ -145,7 +145,7 @@ export ZOO_CLIENT_PASSWORD="${ZOO_CLIENT_PASSWORD:-}"
 export ZOO_SERVER_PASSWORDS="${ZOO_SERVER_PASSWORDS:-}"
 
 # Admin server https://zookeeper.apache.org/doc/r3.5.7/zookeeperAdmin.html#sc_adminserver
-export ZOO_ADMIN_SERVER_ENABLE="${ZOO_ADMIN_SERVER_ENABLE:-true}"
+export ZOO_ENABLE_ADMIN_SERVER="${ZOO_ENABLE_ADMIN_SERVER:-true}"
 export ZOO_ADMIN_SERVER_PORT_NUMBER="${ZOO_ADMIN_SERVER_PORT_NUMBER:-8080}"
 
 # Custom environment variables may be defined below

--- a/3.7/debian-10/rootfs/opt/bitnami/scripts/zookeeper-env.sh
+++ b/3.7/debian-10/rootfs/opt/bitnami/scripts/zookeeper-env.sh
@@ -62,6 +62,8 @@ zookeeper_env_vars=(
     ZOO_SERVER_USERS
     ZOO_CLIENT_PASSWORD
     ZOO_SERVER_PASSWORDS
+    ZOO_ADMIN_SERVER_PORT_NUMBER
+    ZOO_ADMIN_SERVER_ENABLE
 )
 for env_var in "${zookeeper_env_vars[@]}"; do
     file_env_var="${env_var}_FILE"
@@ -141,5 +143,9 @@ export ZOO_CLIENT_USER="${ZOO_CLIENT_USER:-}"
 export ZOO_SERVER_USERS="${ZOO_SERVER_USERS:-}"
 export ZOO_CLIENT_PASSWORD="${ZOO_CLIENT_PASSWORD:-}"
 export ZOO_SERVER_PASSWORDS="${ZOO_SERVER_PASSWORDS:-}"
+
+# Admin server https://zookeeper.apache.org/doc/r3.5.7/zookeeperAdmin.html#sc_adminserver
+export ZOO_ADMIN_SERVER_ENABLE="${ZOO_ADMIN_SERVER_ENABLE:-true}"
+export ZOO_ADMIN_SERVER_PORT_NUMBER="${ZOO_ADMIN_SERVER_PORT_NUMBER:-8080}"
 
 # Custom environment variables may be defined below

--- a/3.7/debian-10/rootfs/opt/bitnami/scripts/zookeeper-env.sh
+++ b/3.7/debian-10/rootfs/opt/bitnami/scripts/zookeeper-env.sh
@@ -145,7 +145,7 @@ export ZOO_CLIENT_PASSWORD="${ZOO_CLIENT_PASSWORD:-}"
 export ZOO_SERVER_PASSWORDS="${ZOO_SERVER_PASSWORDS:-}"
 
 # Admin server https://zookeeper.apache.org/doc/r3.5.7/zookeeperAdmin.html#sc_adminserver
-export ZOO_ENABLE_ADMIN_SERVER="${ZOO_ENABLE_ADMIN_SERVER:-true}"
+export ZOO_ENABLE_ADMIN_SERVER="${ZOO_ENABLE_ADMIN_SERVER:-yes}"
 export ZOO_ADMIN_SERVER_PORT_NUMBER="${ZOO_ADMIN_SERVER_PORT_NUMBER:-8080}"
 
 # Custom environment variables may be defined below

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ The configuration can easily be setup with the Bitnami Apache ZooKeeper Docker i
  - `ZOO_TLS_QUORUM_TRUSTSTORE_FILE`: TrustStore file: Default: No Defaults
  - `ZOO_TLS_QUORUM_TRUSTSTORE_PASSWORD`: TrustStore file password. This can be an environment variable. It will be evaluated by bash. No Defaults
  - `ZOO_TLS_QUORUM_CLIENT_AUTH`: Specifies options to authenticate TLS connections from clients. Available values are: `none`, `want`, `need`. Default: **need**
- - `ZOO_ADMIN_SERVER_ENABLE`: Enable [admin server](https://zookeeper.apache.org/doc/r3.5.7/zookeeperAdmin.html#sc_adminserver). Default: **true**
+ - `ZOO_ENABLE_ADMIN_SERVER`: Enable [admin server](https://zookeeper.apache.org/doc/r3.5.7/zookeeperAdmin.html#sc_adminserver). Default: **true**
  - `ZOO_ADMIN_SERVER_PORT_NUMBER`: [Admin server](https://zookeeper.apache.org/doc/r3.5.7/zookeeperAdmin.html#sc_adminserver) port. Default: **8080**
 
 ```console

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ The configuration can easily be setup with the Bitnami Apache ZooKeeper Docker i
  - `ZOO_TLS_QUORUM_TRUSTSTORE_FILE`: TrustStore file: Default: No Defaults
  - `ZOO_TLS_QUORUM_TRUSTSTORE_PASSWORD`: TrustStore file password. This can be an environment variable. It will be evaluated by bash. No Defaults
  - `ZOO_TLS_QUORUM_CLIENT_AUTH`: Specifies options to authenticate TLS connections from clients. Available values are: `none`, `want`, `need`. Default: **need**
- - `ZOO_ENABLE_ADMIN_SERVER`: Enable [admin server](https://zookeeper.apache.org/doc/r3.5.7/zookeeperAdmin.html#sc_adminserver). Default: **true**
+ - `ZOO_ENABLE_ADMIN_SERVER`: Enable [admin server](https://zookeeper.apache.org/doc/r3.5.7/zookeeperAdmin.html#sc_adminserver). Default: **yes**
  - `ZOO_ADMIN_SERVER_PORT_NUMBER`: [Admin server](https://zookeeper.apache.org/doc/r3.5.7/zookeeperAdmin.html#sc_adminserver) port. Default: **8080**
 
 ```console

--- a/README.md
+++ b/README.md
@@ -223,6 +223,8 @@ The configuration can easily be setup with the Bitnami Apache ZooKeeper Docker i
  - `ZOO_TLS_QUORUM_TRUSTSTORE_FILE`: TrustStore file: Default: No Defaults
  - `ZOO_TLS_QUORUM_TRUSTSTORE_PASSWORD`: TrustStore file password. This can be an environment variable. It will be evaluated by bash. No Defaults
  - `ZOO_TLS_QUORUM_CLIENT_AUTH`: Specifies options to authenticate TLS connections from clients. Available values are: `none`, `want`, `need`. Default: **need**
+ - `ZOO_ADMIN_SERVER_ENABLE`: Enable [admin server](https://zookeeper.apache.org/doc/r3.5.7/zookeeperAdmin.html#sc_adminserver). Default: **true**
+ - `ZOO_ADMIN_SERVER_PORT_NUMBER`: [Admin server](https://zookeeper.apache.org/doc/r3.5.7/zookeeperAdmin.html#sc_adminserver) port. Default: **8080**
 
 ```console
 $ docker run --name zookeeper -e ZOO_SERVER_ID=1 bitnami/zookeeper:latest


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

ZOO_ENABLE_ADMIN_SERVER, ZOO_ADMIN_SERVER_PORT_NUMBER added for [Zookeeper admin server](https://zookeeper.apache.org/doc/r3.5.7/zookeeperAdmin.html#sc_adminserver), version 3.7

**Benefits**

<!-- What benefits will be realized by the code change? -->

Since Zookeeper 3.5.0 new feature of the admin web server is available. But not possible to control it with env variables. The default port is 8080 and it may conflict with other applications with the same network. 

For example, I ran the performance test with [Thingsboard](https://thingsboard.io/docs/reference/performance/) + Postgres + Kafka + Zookeeper and have a port conflict because of network=host (for the simplicity and performance).

Port 8080 are widely used by developers for the webserver and the ability to change the port is mandatory.

Also, it may useful to disable this feature to save some resources and improve security.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

https://github.com/bitnami/bitnami-docker-zookeeper/issues/50

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
Here is my draft example that motivates me to make this request (I don't really want to change my main application port because of Zookeeper:

```bash
version: '3'
services:
  zookeeper:
    image: docker.io/bitnami/zookeeper:3.7
    network_mode: "host"
    restart: "always"
    environment:
      - ALLOW_ANONYMOUS_LOGIN=yes
  kafka:
    image: docker.io/bitnami/kafka:3
    network_mode: "host"
    restart: "always"
    environment:
      - KAFKA_CFG_ZOOKEEPER_CONNECT=localhost:2181
      - ALLOW_PLAINTEXT_LISTENER=yes
    depends_on:
      - zookeeper
  postgres:
    image: "postgres:14"
    network_mode: "host"
    restart: "always"
    environment:
      POSTGRES_DB: "thingsboard"
      POSTGRES_PASSWORD: "postgres"
  tb:
    depends_on:
      - postgres
      - kafka
    image: "thingsboard/tb"
    network_mode: "host"
    restart: "always"
    environment:
      DATABASE_TS_TYPE: "sql"
      TB_QUEUE_TYPE: "kafka"
      TB_KAFKA_BATCH_SIZE: "65536" # default is 16384 - it helps to produce messages much efficiently
      TB_KAFKA_LINGER_MS: "5" # default is 1
      TB_QUEUE_KAFKA_MAX_POLL_RECORDS: "4096"
      TB_SERVICE_ID: "tb-node-0"
      # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
      HTTP_BIND_PORT: "8888" # on port 8080 zookeeper runs admin server, there is no option to move it !!!!!!!!!!!!!!!!!!!
      # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
      TB_QUEUE_RE_MAIN_PACK_PROCESSING_TIMEOUT_MS: "30000"
      # Postgres connection
      SPRING_JPA_DATABASE_PLATFORM: "org.hibernate.dialect.PostgreSQLDialect"
      SPRING_DRIVER_CLASS_NAME: "org.postgresql.Driver"
      SPRING_DATASOURCE_URL: "jdbc:postgresql://localhost:5432/thingsboard"
      SPRING_DATASOURCE_USERNAME: "postgres"
      SPRING_DATASOURCE_PASSWORD: "postgres"
      # Java options for 4G instance and JMX enabled
      JAVA_OPTS: " -Xmx3072M -Xms3072M -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=9999 -Dcom.sun.management.jmxremote.rmi.port=9999 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=127.0.0.1"
```
