### PR TITLE
Configure Zookeeper parameter using ZOO_CFG_ environment variables

### DIFF
--- a/3.5/debian-10/rootfs/opt/bitnami/scripts/libzookeeper.sh
+++ b/3.5/debian-10/rootfs/opt/bitnami/scripts/libzookeeper.sh
@@ -146,6 +146,24 @@ zookeeper_initialize() {
 }
 
 ########################
+# Configure Zookeeper configuration files from environment variables
+# Globals:
+#   ZOO_*
+# Arguments:
+#   None
+# Returns:
+#   None
+#########################
+zookeeper_configure_from_environment_variables() {
+    # Map environment variables to config properties
+    for var in "${!ZOO_CFG_@}"; do
+        key="$(echo "$var" | sed -e 's/^ZOO_CFG_//g' -e 's/_/\./g')"
+        value="${!var}"
+        zookeeper_conf_set "$ZOO_CONF_FILE" "$key" "$value"
+    done
+}
+
+########################
 # Generate the configuration files for ZooKeeper
 # Globals:
 #   ZOO_*
@@ -224,6 +242,8 @@ zookeeper_generate_conf() {
         zookeeper_conf_set "$ZOO_CONF_FILE" ssl.quorum.trustStore.location "$ZOO_TLS_QUORUM_TRUSTSTORE_FILE"
         [[ -n "$ZOO_TLS_QUORUM_TRUSTSTORE_PASSWORD" ]] && zookeeper_conf_set "$ZOO_CONF_FILE" ssl.quorum.trustStore.password "$ZOO_TLS_QUORUM_TRUSTSTORE_PASSWORD"
     fi
+
+    zookeeper_configure_from_environment_variables
 }
 
 ########################

--- a/3.6/debian-10/rootfs/opt/bitnami/scripts/libzookeeper.sh
+++ b/3.6/debian-10/rootfs/opt/bitnami/scripts/libzookeeper.sh
@@ -146,6 +146,24 @@ zookeeper_initialize() {
 }
 
 ########################
+# Configure Zookeeper configuration files from environment variables
+# Globals:
+#   ZOO_*
+# Arguments:
+#   None
+# Returns:
+#   None
+#########################
+zookeeper_configure_from_environment_variables() {
+    # Map environment variables to config properties
+    for var in "${!ZOO_CFG_@}"; do
+        key="$(echo "$var" | sed -e 's/^ZOO_CFG_//g' -e 's/_/\./g')"
+        value="${!var}"
+        zookeeper_conf_set "$ZOO_CONF_FILE" "$key" "$value"
+    done
+}
+
+########################
 # Generate the configuration files for ZooKeeper
 # Globals:
 #   ZOO_*
@@ -224,6 +242,8 @@ zookeeper_generate_conf() {
         zookeeper_conf_set "$ZOO_CONF_FILE" ssl.quorum.trustStore.location "$ZOO_TLS_QUORUM_TRUSTSTORE_FILE"
         [[ -n "$ZOO_TLS_QUORUM_TRUSTSTORE_PASSWORD" ]] && zookeeper_conf_set "$ZOO_CONF_FILE" ssl.quorum.trustStore.password "$ZOO_TLS_QUORUM_TRUSTSTORE_PASSWORD"
     fi
+
+    zookeeper_configure_from_environment_variables
 }
 
 ########################

--- a/3.7/debian-10/rootfs/opt/bitnami/scripts/libzookeeper.sh
+++ b/3.7/debian-10/rootfs/opt/bitnami/scripts/libzookeeper.sh
@@ -146,6 +146,24 @@ zookeeper_initialize() {
 }
 
 ########################
+# Configure Zookeeper configuration files from environment variables
+# Globals:
+#   ZOO_*
+# Arguments:
+#   None
+# Returns:
+#   None
+#########################
+zookeeper_configure_from_environment_variables() {
+    # Map environment variables to config properties
+    for var in "${!ZOO_CFG_@}"; do
+        key="$(echo "$var" | sed -e 's/^ZOO_CFG_//g' -e 's/_/\./g')"
+        value="${!var}"
+        zookeeper_conf_set "$ZOO_CONF_FILE" "$key" "$value"
+    done
+}
+
+########################
 # Generate the configuration files for ZooKeeper
 # Globals:
 #   ZOO_*
@@ -224,6 +242,8 @@ zookeeper_generate_conf() {
         zookeeper_conf_set "$ZOO_CONF_FILE" ssl.quorum.trustStore.location "$ZOO_TLS_QUORUM_TRUSTSTORE_FILE"
         [[ -n "$ZOO_TLS_QUORUM_TRUSTSTORE_PASSWORD" ]] && zookeeper_conf_set "$ZOO_CONF_FILE" ssl.quorum.trustStore.password "$ZOO_TLS_QUORUM_TRUSTSTORE_PASSWORD"
     fi
+
+    zookeeper_configure_from_environment_variables
 }
 
 ########################

--- a/3.8/debian-10/rootfs/opt/bitnami/scripts/libzookeeper.sh
+++ b/3.8/debian-10/rootfs/opt/bitnami/scripts/libzookeeper.sh
@@ -146,6 +146,24 @@ zookeeper_initialize() {
 }
 
 ########################
+# Configure Zookeeper configuration files from environment variables
+# Globals:
+#   ZOO_*
+# Arguments:
+#   None
+# Returns:
+#   None
+#########################
+zookeeper_configure_from_environment_variables() {
+    # Map environment variables to config properties
+    for var in "${!ZOO_CFG_@}"; do
+        key="$(echo "$var" | sed -e 's/^ZOO_CFG_//g' -e 's/_/\./g')"
+        value="${!var}"
+        zookeeper_conf_set "$ZOO_CONF_FILE" "$key" "$value"
+    done
+}
+
+########################
 # Generate the configuration files for ZooKeeper
 # Globals:
 #   ZOO_*
@@ -224,6 +242,8 @@ zookeeper_generate_conf() {
         zookeeper_conf_set "$ZOO_CONF_FILE" ssl.quorum.trustStore.location "$ZOO_TLS_QUORUM_TRUSTSTORE_FILE"
         [[ -n "$ZOO_TLS_QUORUM_TRUSTSTORE_PASSWORD" ]] && zookeeper_conf_set "$ZOO_CONF_FILE" ssl.quorum.trustStore.password "$ZOO_TLS_QUORUM_TRUSTSTORE_PASSWORD"
     fi
+
+    zookeeper_configure_from_environment_variables
 }
 
 ########################

--- a/README.md
+++ b/README.md
@@ -227,6 +227,8 @@ The configuration can easily be setup with the Bitnami Apache ZooKeeper Docker i
  - `ZOO_ENABLE_ADMIN_SERVER`: Enable [admin server](https://zookeeper.apache.org/doc/r3.5.7/zookeeperAdmin.html#sc_adminserver). Default: **yes**
  - `ZOO_ADMIN_SERVER_PORT_NUMBER`: [Admin server](https://zookeeper.apache.org/doc/r3.5.7/zookeeperAdmin.html#sc_adminserver) port. Default: **8080**
 
+Additionally, any environment variable beginning with `ZOO_CFG_` can be used to configure any Zookeeper parameter. For example, use `ZOO_CFG_ssl_quorum_hostnameVerification` in order to configure `ssl.quorum.hostnameVerification`.
+
 ```console
 $ docker run --name zookeeper -e ZOO_SERVER_ID=1 bitnami/zookeeper:latest
 ```


### PR DESCRIPTION
**Issue**

Currently, it is not possible to set arbitrary zookeeper configuration parameters using environment variables.

**Description of the change**

Extend `libzookeeper.sh` to set arbitrary Zookeeper parameters. The changes are based on `libkafka.sh` from Bitnami's Kafka docker image: https://github.com/bitnami/bitnami-docker-kafka/blob/0a053e3e62636643b1e86952f862f3c6abd76e85/3.1/debian-10/rootfs/opt/bitnami/scripts/libkafka.sh#L646-L666

**Benefits**

It is possible to set any Zookeeper parameter using environment variables.

**Possible drawbacks**

Variables set by ZOO_CFG are not validated using e.g. zookeeper_validate()

**Applicable issues**

See https://github.com/bitnami/bitnami-docker-zookeeper/issues/76

**Additional information**

It would be more consistent to use all upper-case environment variables. E.g. `ZOO_CFG_SSL_QUORUM_HOSTNAMEVERIFICATION` instead of `ZOO_CFG_ssl_quorum_hostnameVerification`.  However, I did not yet find an easy solution to implement this. Ideas would be to replace camelCase names using regex in `zookeeper_configure_from_environment_variables`. However, this would require a list of all known cases and the function needs to be updated for possible future configuration options.
 

